### PR TITLE
Lib/Graphql/Client: Cache new WorkspaceUser

### DIFF
--- a/src/lib/graphql/client.ts
+++ b/src/lib/graphql/client.ts
@@ -70,6 +70,8 @@ export const client = new ApolloClient({
             switch (responseObject.__typename) {
                 case "User":
                     return `${responseObject.__typename}:${responseObject.email}`;
+                case "WorkspaceUser":
+                    return `${responseObject.__typename}:${responseObject.email}`;
                 default:
                     return `${responseObject.__typename}:${responseObject.uuid}`;
             }


### PR DESCRIPTION
I've created a new type called WorkspaceUser in GraphQL which can be cached by .email, like User.